### PR TITLE
CD++ simulator as git-submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 .vscode/
 .coverage
+colonel/wrapper/config.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CDPP_ExtendedStates-codename-Santi"]
+	path = CDPP_ExtendedStates-codename-Santi
+	url = git@github.com:SimulationEverywhere/CDPP_ExtendedStates-codename-Santi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CD++ Simulator"]
 	path = cdpp
-	url = git@github.com:SimulationEverywhere/CDPP_ExtendedStates-codename-Santi.git
+	url = https://github.com/SimulationEverywhere/CDPP_ExtendedStates-codename-Santi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "CDPP_ExtendedStates-codename-Santi"]
-	path = CDPP_ExtendedStates-codename-Santi
+[submodule "CD++ Simulator"]
+	path = cdpp
 	url = git@github.com:SimulationEverywhere/CDPP_ExtendedStates-codename-Santi.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements-dev.txt
+  - bash setup.sh
 script:
   - make remote
 after_success:

--- a/colonel/wrapper/wrapper.py
+++ b/colonel/wrapper/wrapper.py
@@ -68,7 +68,7 @@ class LibraryDefinedDirectoryExecutableDiscoverer(ExecutableDiscoverer):
 class Wrapper:
     CDPP_BIN = 'cd++'
     CDPP_EXECUTABLE_ENV_VAR = 'CDPP_BIN'
-    CDPP_LIBRARY_DEFINED_EXECUTABLE_PATH = '~/Facultad/pringles/cdpp_kernel/bin/'
+    CDPP_LIBRARY_DEFINED_EXECUTABLE_PATH = '../../'
 
     DRAWLOG_BIN = 'drawlog'
     simulationAbortedErrorMessage = 'Aborting simulation...\n'

--- a/colonel/wrapper/wrapper.py
+++ b/colonel/wrapper/wrapper.py
@@ -70,7 +70,6 @@ class LibraryDefinedDirectoryExecutableDiscoverer(ExecutableDiscoverer):
 class Wrapper:
     CDPP_BIN = 'cd++'
     CDPP_EXECUTABLE_ENV_VAR = 'CDPP_BIN'
-    CDPP_LIBRARY_DEFINED_EXECUTABLE_PATH = '../../'
 
     DRAWLOG_BIN = 'drawlog'
     simulationAbortedErrorMessage = 'Aborting simulation...\n'

--- a/colonel/wrapper/wrapper.py
+++ b/colonel/wrapper/wrapper.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from colonel.wrapper.errors import SimulatorExecutableNotFound
 
+from colonel.wrapper.config import CDPP_BIN_PATH
+
 
 class ExecutableDiscoverer():
     def discover(self) -> Optional[str]:
@@ -58,7 +60,7 @@ class LibraryEnvironmentVarExecutableDiscoverer(ExecutableDiscoverer):
 
 class LibraryDefinedDirectoryExecutableDiscoverer(ExecutableDiscoverer):
     def do_discover(self):
-        executable_route = os.path.join(Wrapper.CDPP_LIBRARY_DEFINED_EXECUTABLE_PATH,
+        executable_route = os.path.join(CDPP_BIN_PATH,
                                         Wrapper.CDPP_BIN)
         if ExecutableDiscoverer.is_executable_file(executable_route):
             return executable_route
@@ -78,8 +80,6 @@ class Wrapper:
 
     def discover_executable_route(self):
         discoverer = CompoundExecutableDiscoverer(
-            PathEnvironmentVarExecutableDiscoverer(),
-            LibraryEnvironmentVarExecutableDiscoverer(),
             LibraryDefinedDirectoryExecutableDiscoverer(),
         )
         found_route = discoverer.discover()

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+BASE_PRINGLES_DIR=$(pwd)
+CDPP_BIN_DIR=$BASE_PRINGLES_DIR/cdpp/src/bin
+
+# Clone git submodules recursively (eg. CD++ Simulator)
+git submodule update --init --recursive
+
+# Build simulator to generate binaries
+make -C cdpp/src/
+
+# Generate pringles.config file
+echo "CDPP_BIN_PATH = '$CDPP_BIN_DIR'" >  colonel/wrapper/config.py

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2,19 +2,23 @@ import pytest
 from unittest import mock
 import os
 from colonel.wrapper.wrapper import Wrapper
+from colonel.wrapper.config import CDPP_BIN_PATH
 from colonel.wrapper.errors import SimulatorExecutableNotFound
 
 
 TEST_PATH_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 TEST_EXECUTABLE = os.path.join(TEST_PATH_DIRECTORY, Wrapper.CDPP_BIN)
+CDPP_BIN_EXECUTABLE_PATH = os.path.join(CDPP_BIN_PATH, Wrapper.CDPP_BIN)
 
 
+@pytest.mark.skip(reason = "Deprecated executable locator")
 @mock.patch.dict(os.environ, {'PATH': ''})
 def test_no_simulator_executable_found():
     with pytest.raises(SimulatorExecutableNotFound):
         wrapper = Wrapper()  # noqa: F841
 
 
+@pytest.mark.skip(reason = "Deprecated executable locator")
 @mock.patch.dict(os.environ, {'PATH': TEST_PATH_DIRECTORY})
 def test_simulator_executable_found_in_PATH():
     # Set current working directory in path, so it discovers 'cd++' in tests/
@@ -22,14 +26,13 @@ def test_simulator_executable_found_in_PATH():
     assert wrapper.executable_route == TEST_EXECUTABLE
 
 
+@pytest.mark.skip(reason = "Deprecated executable locator")
 @mock.patch.dict(os.environ, {'PATH': '', Wrapper.CDPP_EXECUTABLE_ENV_VAR: TEST_PATH_DIRECTORY})
 def test_simulator_executable_found_in_library_env_var():
     wrapper = Wrapper()
     assert wrapper.executable_route == TEST_EXECUTABLE
 
 
-@mock.patch.object(Wrapper, 'CDPP_LIBRARY_DEFINED_EXECUTABLE_PATH', TEST_PATH_DIRECTORY)
-@mock.patch.dict(os.environ, {'PATH': ''})
 def test_simulator_executable_found_in_library_defined_dir():
     wrapper = Wrapper()
-    assert wrapper.executable_route == TEST_EXECUTABLE
+    assert wrapper.executable_route == CDPP_BIN_EXECUTABLE_PATH


### PR DESCRIPTION
- Configured the CD++ simulator project as a git-submodule.
- Added setup script to clone submodule, and defined config file with path to simulator binaries.
- Adapted custom ExecutableLocator.
- Skipped old tests.