### PR TITLE
First version for Atomic metadata extractor

### DIFF
--- a/colonel/models/models.py
+++ b/colonel/models/models.py
@@ -76,14 +76,14 @@ class InPort(Port):
     """Input port.
     """
     def __init__(self, name, owner):
-        return super().__init__(name, owner)
+        super().__init__(name, owner)
 
 
 class OutPort(Port):
     """Output port.
     """
     def __init__(self, name, owner):
-        return super().__init__(name, owner)
+        super().__init__(name, owner)
 
 
 class Link:

--- a/colonel/models/models.py
+++ b/colonel/models/models.py
@@ -67,11 +67,17 @@ class Port:
 
 
 class InPort(Port):
-    pass
+    """Input port.
+    """
+    def __init__(self, name, owner):
+        return super().__init__(name, owner)
 
 
 class OutPort(Port):
-    pass
+    """Output port.
+    """
+    def __init__(self, name, owner):
+        return super().__init__(name, owner)
 
 
 class Link:

--- a/colonel/models/models.py
+++ b/colonel/models/models.py
@@ -65,25 +65,17 @@ class Port:
     def get_identifier_for(self, model: Model) -> str:
         return self.name if model == self.owner else f"{self.name}@{self.owner.name}"
 
-    def __eq__(self, other):
-        if not isinstance(other, Port):
-            return False
-        other_port: Port = other
-        return self.name == other_port.name and self.owner == other_port.owner
-
 
 class InPort(Port):
     """Input port.
     """
-    def __init__(self, name, owner):
-        super().__init__(name, owner)
+    pass
 
 
 class OutPort(Port):
     """Output port.
     """
-    def __init__(self, name, owner):
-        super().__init__(name, owner)
+    pass
 
 
 class Link:

--- a/colonel/models/models.py
+++ b/colonel/models/models.py
@@ -65,6 +65,12 @@ class Port:
     def get_identifier_for(self, model: Model) -> str:
         return self.name if model == self.owner else f"{self.name}@{self.owner.name}"
 
+    def __eq__(self, other):
+        if not isinstance(other, Port):
+            return False
+        other_port: Port = other
+        return self.name == other_port.name and self.owner == other_port.owner
+
 
 class InPort(Port):
     """Input port.

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -1,15 +1,26 @@
 from typing import Union, List
+from pyparsing import Word, Literal, alphanums, ParserElement
 from colonel.models import InPort, OutPort, Port
 from io import StringIO  # File typing
 
 
 class AtomicMetadataExtractor:
     """Extractor from ports metadata from Atomcis cpp file."""
+
     def __init__(self, source: Union[str, StringIO]):
         if isinstance(source, str):
             self.source = source
         else:
             self.source = source.read()
 
+        self.input_port_expression_parser: ParserElement = Literal(
+            "@InputPort(\"").setResultsName("type") + Word(alphanums).setResultsName("name") + Literal("\")")
+        self.output_port_expression_parser: ParserElement = Literal(
+            "@OutputPort(\"").setResultsName("type") + Word(alphanums).setResultsName("name") + Literal("\")")
+
     def extract_ports(self) -> List[Port]:
-        return []
+        exctracted_ports = []
+        for line in self.source.splitlines():
+            parsed_input_port = self.input_port_expression_parser.parseString(line)
+
+        return exctracted_ports

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -1,0 +1,16 @@
+from typing import Union, List
+from colonel.models import InPort, OutPort, Port
+from io import StringIO  # File typing
+
+
+class AtomicMetadataExtractor:
+    """Extractor from ports metadata from Atomcis cpp file."""
+    def __init__(self, source: Union[str, StringIO]):
+        if isinstance(source, str):
+            self.source = source
+        else:
+            self.source = source.read()
+
+    def extract_ports(self) -> List[Port]:
+        return []
+    

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -1,8 +1,7 @@
 from typing import Union, List
-from pyparsing import Word, Literal, alphanums, ParseException, delimitedList, ParserElement, Optional
-from colonel.models import InPort, OutPort, Port
+from pyparsing import Word, Literal, alphanums, ParseException, delimitedList,\
+    ParserElement, Optional
 from io import StringIO  # File typing
-import re
 
 
 class MetadataParsingException(Exception):
@@ -34,8 +33,6 @@ class AtomicMetadataExtractor:
     output_ports: oport1, oport2
     ```
     """
-
-    CPP_MULTILINE_COMMENT_RE = "/\*(.*)\*/"
 
     def __init__(self, source: Union[str, StringIO]):
         self.source = source
@@ -101,7 +98,7 @@ class CppCommentsLexer:
         self._index = 0
         self._size = len(source)
         self._pushed_symbols = ""
-        self._lexed_comments = []
+        self._lexed_comments: List[str] = []
 
     def _peek(self, n=1):
         return self.source[self._index: self._index + n]

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -6,7 +6,7 @@ from io import StringIO  # File typing
 
 class AtomicMetadataExtractor:
     """Extractor from ports metadata from Atomcis cpp file.
-    
+
     This should be improved to a more richer metadata, such as:
     ```
     @ModelMetadata
@@ -30,7 +30,7 @@ class AtomicMetadataExtractor:
             Literal(")")
 
     def extract_ports(self) -> List[Port]:
-        exctracted_ports = []
+        exctracted_ports: List[Port] = []
         for line in self.source.splitlines():
             try:
                 input_port_result = self.input_port_expression_parser.parseString(line)

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -5,7 +5,16 @@ from io import StringIO  # File typing
 
 
 class AtomicMetadataExtractor:
-    """Extractor from ports metadata from Atomcis cpp file."""
+    """Extractor from ports metadata from Atomcis cpp file.
+    
+    This should be improved to a more richer metadata, such as:
+    ```
+    @ModelMetadata
+    name: some_name
+    input_ports: port1, port2, port3
+    output_ports: oport1, oport2
+    ```
+    """
 
     def __init__(self, source: Union[str, StringIO]):
         if isinstance(source, str):

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -1,5 +1,5 @@
 from typing import Union, List
-from pyparsing import Word, Literal, alphanums, ParserElement
+from pyparsing import Word, Literal, alphanums, ParserElement, ParseException
 from colonel.models import InPort, OutPort, Port
 from io import StringIO  # File typing
 
@@ -14,13 +14,25 @@ class AtomicMetadataExtractor:
             self.source = source.read()
 
         self.input_port_expression_parser: ParserElement = Literal(
-            "@InputPort(\"").setResultsName("type") + Word(alphanums).setResultsName("name") + Literal("\")")
+            "@InputPort(").setResultsName("type") + Word(alphanums).setResultsName("name") +\
+            Literal(")")
         self.output_port_expression_parser: ParserElement = Literal(
-            "@OutputPort(\"").setResultsName("type") + Word(alphanums).setResultsName("name") + Literal("\")")
+            "@OutputPort(").setResultsName("type") + Word(alphanums).setResultsName("name") +\
+            Literal(")")
 
     def extract_ports(self) -> List[Port]:
         exctracted_ports = []
         for line in self.source.splitlines():
-            parsed_input_port = self.input_port_expression_parser.parseString(line)
-
+            try:
+                input_port_result = self.input_port_expression_parser.parseString(line)
+                port_name = input_port_result["name"]
+                exctracted_ports.append(InPort(port_name, None))
+            except ParseException:
+                pass
+            try:
+                output_port_result = self.output_port_expression_parser.parseString(line)
+                port_name = output_port_result["name"]
+                exctracted_ports.append(OutPort(port_name, None))
+            except ParseException:
+                pass
         return exctracted_ports

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import List
 from pyparsing import Word, Literal, alphanums, ParseException, delimitedList,\
     ParserElement, Optional
 from io import StringIO  # File typing
@@ -9,6 +9,9 @@ class MetadataParsingException(Exception):
 
 
 class AtomicMetadata:
+    """Metadata about a atomic model.
+    """
+
     def __init__(self, name: str, input_ports: List[str], output_ports: List[str]):
         self.name = name
         self.input_ports = input_ports
@@ -34,7 +37,12 @@ class AtomicMetadataExtractor:
     ```
     """
 
-    def __init__(self, source: Union[str, StringIO]):
+    def __init__(self, source: StringIO):
+        """Main constructor
+
+        :param source: a C++ containing the model metadata in a multi-line comment
+        :type source: File
+        """
         self.source = source
         self._initialize_parser()
 
@@ -83,10 +91,8 @@ class AtomicMetadataExtractor:
             raise MetadataParsingException(pe)
 
     def extract(self) -> AtomicMetadata:
-        if isinstance(self.source, str):
-            return self._do_extract_from_string(self.source)
-        else:
-            return self._do_extract_from_file(self.source)
+        """Extract the model metadata from the C++ source file."""
+        return self._do_extract_from_file(self.source)
 
 
 class CppCommentsLexer:

--- a/colonel/utils/discovery.py
+++ b/colonel/utils/discovery.py
@@ -13,4 +13,3 @@ class AtomicMetadataExtractor:
 
     def extract_ports(self) -> List[Port]:
         return []
-    

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ max-line-length = 100
 ignore_missing_imports = True
 [mypy-IPython.display]
 ignore_missing_imports = True
+[mypy-pyparsing]
+ignore_missing_imports = True

--- a/tests/resources/queue.h
+++ b/tests/resources/queue.h
@@ -44,8 +44,10 @@ public:
 };
 
 /*
-@InputPort(in)
-@OutputPort(out)
+@ModelMetadata
+name:   Queue
+input_ports: in, done
+output_ports: out
 */
 class Queue : public Atomic
 {

--- a/tests/resources/queue.h
+++ b/tests/resources/queue.h
@@ -1,0 +1,84 @@
+/*******************************************************************
+*
+*  DESCRIPCION: Cola Genérica (on demand)
+*
+*  AUTORES:
+*  	    Ing. Carlos Giorgetti
+*          Iván A. Melgrati
+*          Dra. Ana Rosa Tymoschuk
+*	    v2:Alejandro Troccoli
+*
+*  EMAIL: mailto://cgiorget@frsf.utn.edu.ar
+*         mailto://imelgrat@frsf.utn.edu.ar
+*         mailto://anrotym@alpha.arcride.edu.ar
+*	   mailto://atroccol@dc.uba.ar (v2)
+*
+*  FECHA: 15/10/1999
+*         01/02/2001
+*******************************************************************/
+#ifndef __QUEUE_H
+#define __QUEUE_H
+
+#include <list>
+#include "atomic.h"     	// class Atomic
+#include "atomicstate.h"	//
+#include "value.h"
+#include "VTime.h"
+
+#define QUEUE_MODEL_NAME "Queue"
+
+class QueueState : public AtomicState {
+
+public:
+
+	typedef std::list<value_ptr> ElementList ;
+	ElementList elements ;
+
+	QueueState(){};
+	virtual ~QueueState(){};
+
+	QueueState& operator=(QueueState& thisState); //Assignment
+	void copyState(QueueState *);
+	int  getSize() const;
+
+};
+
+/*
+@InputPort(in)
+@OutputPort(out)
+*/
+class Queue : public Atomic
+{
+public:
+	Queue( const std::string &name = "Queue" );
+	virtual std::string className() const {  return "Queue" ;}
+protected:
+	Model &initFunction();
+	Model &externalFunction( const ExternalMessage & );
+	Model &internalFunction( const InternalMessage & );
+	Model &outputFunction( const CollectMessage & );
+
+	ModelState* allocateState() {
+		return new QueueState;
+	}
+
+private:
+	const Port &in;
+	const Port &done;
+	Port &out;
+
+	VTime preparationTime;
+
+	QueueState::ElementList& elements();
+
+};	// class Queue
+
+/*******************************************************************
+* Shortcuts to state paramters
+*********************************************************************/
+inline
+QueueState::ElementList& Queue::elements() {
+	return ((QueueState*)getCurrentState())->elements;
+}
+
+#endif   //__QUEUE_H

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -1,31 +1,35 @@
 import pytest  # noqa
-from colonel.utils.discovery import AtomicMetadataExtractor
+from colonel.utils.discovery import AtomicMetadataExtractor, MetadataParsingException, AtomicMetadata
 from colonel.models import InPort, OutPort
 
 
-def test_no_port_metadata_does_not_fail():
-    source = "void main(char** argv) {\n\tprintf(\"\");\n}"
-    assert AtomicMetadataExtractor(source).extract_ports() == []
+def test_no_metadata_fails():
+    with pytest.raises(MetadataParsingException):
+        source = "void main(char** argv) {\n\tprintf(\"\");\n}"
+        AtomicMetadataExtractor(source).extract()
 
 
-def test_single_input_port_extracted_correctly():
-    source = "@InputPort(in)"
-    assert AtomicMetadataExtractor(source).extract_ports() == [InPort("in", None)]
+def test_just_model_name_in_metadata():
+    source = """
+    @ModelMetadata
+    name:perro
+    """
+    assert AtomicMetadataExtractor(source).extract() == AtomicMetadata("perro", [], [])
 
 
 def test_single_output_port_extracted_correctly():
     source = "@OutputPort(out)"
-    assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None)]
+    assert AtomicMetadataExtractor(source).extract() == [OutPort("out", None)]
 
 
 def test_multiple_ports_are_extracted_correctly():
     source = "@OutputPort(out)\n@InputPort(perro1)\n@InputPort(gato)"
-    assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None),
+    assert AtomicMetadataExtractor(source).extract() == [OutPort("out", None),
                                                                InPort("perro1", None),
                                                                InPort("gato", None)]
 
 
 def test_model_cpp_file_with_metadata_is_parsed_correctly():
     with open("tests/resources/queue.h", "r") as queue_source_file:
-        assert AtomicMetadataExtractor(queue_source_file).extract_ports() == \
+        assert AtomicMetadataExtractor(queue_source_file).extract() == \
             [InPort("in", None), OutPort("out", None)]

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -23,3 +23,9 @@ def test_multiple_ports_are_extracted_correctly():
     assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None),
                                                                InPort("perro1", None),
                                                                InPort("gato", None)]
+
+
+def test_model_cpp_file_with_metadata_is_parsed_correctly():
+    with open("tests/resources/queue.h", "r") as queue_source_file:
+        assert AtomicMetadataExtractor(queue_source_file).extract_ports() == \
+            [InPort("in", None), OutPort("out", None)]

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -1,12 +1,25 @@
-import pytest
+import pytest  # noqa
 from colonel.utils.discovery import AtomicMetadataExtractor
 from colonel.models import InPort, OutPort
+
+
+def test_no_port_metadata_does_not_fail():
+    source = "void main(char** argv) {\n\tprintf(\"\");\n}"
+    assert AtomicMetadataExtractor(source).extract_ports() == []
 
 
 def test_single_input_port_extracted_correctly():
     source = "@InputPort(in)"
     assert AtomicMetadataExtractor(source).extract_ports() == [InPort("in", None)]
 
+
 def test_single_output_port_extracted_correctly():
     source = "@OutputPort(out)"
     assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None)]
+
+
+def test_multiple_ports_are_extracted_correctly():
+    source = "@OutputPort(out)\n@InputPort(perro1)\n@InputPort(gato)"
+    assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None),
+                                                               InPort("perro1", None),
+                                                               InPort("gato", None)]

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -4,9 +4,9 @@ from colonel.models import InPort, OutPort
 
 
 def test_single_input_port_extracted_correctly():
-    source = "@InputPort(\"in\")"
+    source = "@InputPort(in)"
     assert AtomicMetadataExtractor(source).extract_ports() == [InPort("in", None)]
 
 def test_single_output_port_extracted_correctly():
-    source = "@OutputPort(\"out\")"
+    source = "@OutputPort(out)"
     assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None)]

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -1,0 +1,12 @@
+import pytest
+from colonel.utils.discovery import AtomicMetadataExtractor
+from colonel.models import InPort, OutPort
+
+
+def test_single_input_port_extracted_correctly():
+    source = "@InputPort(\"in\")"
+    assert AtomicMetadataExtractor(source).extract_ports() == [InPort("in", None)]
+
+def test_single_output_port_extracted_correctly():
+    source = "@OutputPort(\"out\")"
+    assert AtomicMetadataExtractor(source).extract_ports() == [OutPort("out", None)]

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -18,18 +18,28 @@ def test_just_model_name_in_metadata():
 
 
 def test_single_output_port_extracted_correctly():
-    source = "@OutputPort(out)"
-    assert AtomicMetadataExtractor(source).extract() == [OutPort("out", None)]
+    source = """
+    @ModelMetadata
+    name:perro
+    output_ports: perro, gato
+    """
+    assert AtomicMetadataExtractor(source).extract(
+    ) == AtomicMetadata("perro", [], ["perro", "gato"])
 
 
 def test_multiple_ports_are_extracted_correctly():
-    source = "@OutputPort(out)\n@InputPort(perro1)\n@InputPort(gato)"
-    assert AtomicMetadataExtractor(source).extract() == [OutPort("out", None),
-                                                               InPort("perro1", None),
-                                                               InPort("gato", None)]
+    source = """
+    @ModelMetadata
+    name:   perro
+    input_ports: ornito, rinco
+    output_ports: perro   , gato
+    """
+    assert AtomicMetadataExtractor(source).extract() == AtomicMetadata("perro",
+                                                                       ["ornito", "rinco"],
+                                                                       ["perro", "gato"])
 
 
 def test_model_cpp_file_with_metadata_is_parsed_correctly():
     with open("tests/resources/queue.h", "r") as queue_source_file:
         assert AtomicMetadataExtractor(queue_source_file).extract() == \
-            [InPort("in", None), OutPort("out", None)]
+                AtomicMetadata("Queue", ["in", "done"], ["out"])


### PR DESCRIPTION
First iteration of a simple metadata extractor. For now the convention will be:
- Just header files will be extracted.
- The capitalized header file name will be the model name.
- The metadata just consists on output/input ports declarations.