### PR TITLE
Custom working directory configurable from run_simulation

### DIFF
--- a/pringles/simulator/simulator.py
+++ b/pringles/simulator/simulator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import subprocess
 import tempfile
+import uuid
 import logging
 
 import pandas as pd
@@ -174,29 +175,49 @@ class Simulator:
                        duration: Optional[VirtualTime] = None,
                        events: Optional[List[Event]] = None,
                        use_simulator_logs: bool = True,
-                       use_simulator_out: bool = True):
+                       use_simulator_out: bool = True,
+                       custom_simulation_wd: Optional[str] = None) -> SimulationResult:
+        """Run the simulation in the targeted CD++ simulator instance.
+
+        :param top_model: The top model of the simulation to be ran
+        :type top_model: Model
+        :param duration: Simulation duration, defaults to None
+        :type duration: Optional[VirtualTime], optional
+        :param events: List of external events, defaults to None
+        :type events: Optional[List[Event]], optional
+        :param use_simulator_logs: True if simulator logs should be generated, defaults to True
+        :type use_simulator_logs: bool, optional
+        :param use_simulator_out: True if simulator outputs should be captured, defaults to True
+        :type use_simulator_out: bool, optional
+        :param custom_simulation_wd: Custom working directory in which to dump all "compiled"
+            models, logs, outputs and events file, defaults to None
+        :type custom_simulation_wd: Optional[str], optional
+        :raises SimulatorExecutableNotFound: CD++ executable was not found in the provided directory
+        :return: A SimulationResult, containing all data concerning the simulation results.
+        :rtype: SimulationResult
+        """
         logged_messages = 'XY'
+        dumped_top_model_path = self.dump_model_in_file(top_model,
+                                                        custom_simulation_wd)
         commands_list = [self.executable_route,
-                         "-m" + self.dump_model_in_file(top_model),
+                         "-m" + dumped_top_model_path,
                          "-L" + logged_messages]
         if duration is not None:
             commands_list.append("-t" + str(duration))
 
         if events is not None:
             events_list = events
-            events_file_path = self.dump_events_in_file(events_list)
+            events_file_path = self.dump_events_in_file(events_list, custom_simulation_wd)
             commands_list.append("-e" + events_file_path)
 
         # Simulation logs
         if use_simulator_logs:
-            logs_handle, logs_path = tempfile.mkstemp()
-            os.close(logs_handle)
+            logs_path = Simulator._new_temporal_file(custom_simulation_wd, "logs")
             commands_list.append("-l" + logs_path)
 
         # Simulation output file
         if use_simulator_out:
-            output_handle, output_path = tempfile.mkstemp()
-            os.close(output_handle)
+            output_path = Simulator._new_temporal_file(custom_simulation_wd, "output")
             commands_list.append("-o" + output_path)
 
         process_result = subprocess.run(commands_list, capture_output=True, check=True)
@@ -209,22 +230,40 @@ class Simulator:
                                 output_path=output_path)
 
     @staticmethod
-    def dump_events_in_file(events: List[Event]) -> str:
-        file_descriptor, path = tempfile.mkstemp()
+    def dump_events_in_file(events: List[Event], custom_wd: Optional[str] = None) -> str:
+        path = Simulator._new_temporal_file(custom_wd, "events")
         with open(path, "w") as events_file:
             for event in events:
                 events_file.write(event.serialize() + "\n")
 
-        os.close(file_descriptor)
         return path
 
     @staticmethod
-    def dump_model_in_file(model: Model) -> str:
-        file_descriptor, path = tempfile.mkstemp()
+    def _new_temporal_file(working_dir: Optional[str] = None,
+                           file_prefix: Optional[str] = None) -> str:
+        temporal_path = None
+        if working_dir is None:
+            unused_file_handle, temporal_path = tempfile.mkstemp()
+            os.close(unused_file_handle)
+        else:
+            # Using uuid as unique filename generator
+            # TODO: It would be nice to make this uuid represent the whole simulation,
+            # so in some way this should be shared cross-simulation, and be used by the
+            # SimulationResult as an unique identifier.
+            temporal_path = os.path.join(working_dir, str(uuid.uuid4()))
+        # Insert prefix into temporal path
+        file_segments = temporal_path.split("/")
+        if file_prefix is not None:
+            file_segments[-1] = file_prefix + file_segments[-1]
+        # Reassemble path
+        return "/".join(file_segments)
+
+    @staticmethod
+    def dump_model_in_file(model: Model, custom_wd: Optional[str]) -> str:
+        path = Simulator._new_temporal_file(custom_wd, "top_model")
         with open(path, "w") as model_file:
             model_file.write(MaSerializer.serialize(model))
 
-        os.close(file_descriptor)
         return path
 
     def find_executable_route(self, cdpp_bin_path: str) -> str:

--- a/pringles/simulator/simulator.py
+++ b/pringles/simulator/simulator.py
@@ -255,7 +255,7 @@ class Simulator:
         # Insert prefix into temporal path
         file_segments = temporal_path.split("/")
         if file_prefix is not None:
-            file_segments[-1] = file_prefix + file_segments[-1]
+            file_segments[-1] = file_prefix + "_" + file_segments[-1]
         # Reassemble path
         return "/".join(file_segments)
 

--- a/pringles/simulator/simulator.py
+++ b/pringles/simulator/simulator.py
@@ -250,7 +250,8 @@ class Simulator:
             # TODO: It would be nice to make this uuid represent the whole simulation,
             # so in some way this should be shared cross-simulation, and be used by the
             # SimulationResult as an unique identifier.
-            temporal_path = os.path.join(working_dir, str(uuid.uuid4()))
+            random_filename = str(uuid.uuid4().hex)
+            temporal_path = os.path.join(working_dir, random_filename)
         # Insert prefix into temporal path
         file_segments = temporal_path.split("/")
         if file_prefix is not None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -34,11 +34,13 @@ def test_run_simulation_in_custom_wd():
     simulator = Simulator(CDPP_BIN_PATH)
     top_model, events = _make_queue_top_model_with_events()
     temp_path = tempfile.mkdtemp()
-    simulator.run_simulation(top_model, events=events, custom_simulation_wd=temp_path)
+    simulator.run_simulation(top_model, events=events, simulation_wd=temp_path)
     files_found = False
     for _, _, files in os.walk(temp_path):
         # Assert there are files
-        files_found = len(files) > 0
+        files_found = len(files) > 0 if not files_found else files_found
+        if not files_found:
+            continue
         # Assert there's an event, logs, top_model and output file
         assert any([filename.startswith("top_model") for filename in files])
         assert any([filename.startswith("events") for filename in files])

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,9 +1,11 @@
 import pytest  # noqa
 import os
+import tempfile
+from typing import List, Tuple
 from pringles.simulator import Simulator
 from pringles.simulator.errors import SimulatorExecutableNotFound
 from pringles.utils import VirtualTime
-from pringles.models import Coupled, AtomicModelBuilder, Event
+from pringles.models import Coupled, Model, AtomicModelBuilder, Event
 
 
 TEST_PATH_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
@@ -24,7 +26,26 @@ def test_simulator_executable_not_found_raises():
 
 def test_no_exception_raised_in_simulation():
     simulator = Simulator(CDPP_BIN_PATH)
+    top_model, events = _make_queue_top_model_with_events()
+    simulator.run_simulation(top_model, events=events)
 
+
+def test_run_simulation_in_custom_wd():
+    simulator = Simulator(CDPP_BIN_PATH)
+    top_model, events = _make_queue_top_model_with_events()
+    temp_path = tempfile.mkdtemp()
+    simulator.run_simulation(top_model, events=events, custom_simulation_wd=temp_path)
+    for _, _, files in os.walk(temp_path):
+        # Assert there are files
+        assert len(files) > 0
+        # Assert there's an event, logs, top_model and output file
+        assert any([filename.startswith("top_model") for filename in files])
+        assert any([filename.startswith("events") for filename in files])
+        assert any([filename.startswith("logs") for filename in files])
+        assert any([filename.startswith("output") for filename in files])
+
+
+def _make_queue_top_model_with_events() -> Tuple[Model, List[Event]]:
     Queue = AtomicModelBuilder().with_name("Queue").build()
     sample_queue = Queue("sample_queue", preparation="0:0:5:0")
     sample_queue.add_inport("in").add_outport("out")
@@ -42,4 +63,4 @@ def test_no_exception_raised_in_simulation():
         Event(VirtualTime.of_seconds(30), incoming_event_port, 20.),
     ]
 
-    simulator.run_simulation(top_model, events=events)
+    return top_model, events

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -35,14 +35,16 @@ def test_run_simulation_in_custom_wd():
     top_model, events = _make_queue_top_model_with_events()
     temp_path = tempfile.mkdtemp()
     simulator.run_simulation(top_model, events=events, custom_simulation_wd=temp_path)
+    files_found = False
     for _, _, files in os.walk(temp_path):
         # Assert there are files
-        assert len(files) > 0
+        files_found = len(files) > 0
         # Assert there's an event, logs, top_model and output file
         assert any([filename.startswith("top_model") for filename in files])
         assert any([filename.startswith("events") for filename in files])
         assert any([filename.startswith("logs") for filename in files])
         assert any([filename.startswith("output") for filename in files])
+    assert files_found
 
 
 def _make_queue_top_model_with_events() -> Tuple[Model, List[Event]]:


### PR DESCRIPTION
First iteration for https://github.com/colonelpringles/pringles/issues/41

A custom working directory can be configured from the run_simulation method. All model, events, log and output files will be dumped in there.

Also, some first iteration of the simulation_id has been added. Need to make it simulation wide, since its creating an uuid for each simulation member (model files, log files, etc.).