### PR TITLE
Atomic names should support underscores and hyphens

### DIFF
--- a/pringles/utils/discovery.py
+++ b/pringles/utils/discovery.py
@@ -34,6 +34,8 @@ class AtomicMetadataExtractor:
     ```
     """
 
+    __supported_name_characters = alphanums + '-_'
+
     def __init__(self, source: TextIO):
         """Main constructor
 
@@ -44,11 +46,14 @@ class AtomicMetadataExtractor:
         self._initialize_parser()
 
     def _initialize_parser(self):
-        port_names_list = delimitedList(Word(alphanums + '-_'))
+        name_matcher = Word(
+            AtomicMetadataExtractor.__supported_name_characters
+        )
+        port_names_list = delimitedList(name_matcher)
         metadata_start_keyword = Literal("@ModelMetadata")
         self.parser: ParserElement = metadata_start_keyword +\
             Literal("name:") +\
-            Word(alphanums).setResultsName("model_name") +\
+            name_matcher.setResultsName("model_name") +\
             Optional(
                 Literal("input_ports:") +
                 port_names_list.setResultsName("input_ports")

--- a/tests/test_atomic_metadata_extractor.py
+++ b/tests/test_atomic_metadata_extractor.py
@@ -1,7 +1,7 @@
 import pytest  # noqa
 from pringles.utils.errors import MetadataParsingException
 from pringles.utils.discovery import (AtomicMetadataExtractor,
-                                     AtomicMetadata)
+                                      AtomicMetadata)
 
 
 # Helper to hide the private method call
@@ -21,6 +21,21 @@ def test_just_model_name_in_metadata():
     name:perro
     """
     assert extract_metadata_from_string(source) == AtomicMetadata("perro", [], [])
+
+
+@pytest.mark.parametrize("name", [
+    ("perro"),
+    ("perro_loco"),
+    ("perro-loco"),
+    ("123perro-loco"),
+    ("perro-LoCo_546")
+])
+def test_supported_model_names(name: str):
+    source = """
+    @ModelMetadata
+    name:%s
+    """ % name
+    assert extract_metadata_from_string(source) == AtomicMetadata(name, [], [])
 
 
 def test_single_output_port_extracted_correctly():


### PR DESCRIPTION
Fixing https://github.com/colonelpringles/pringles/issues/62